### PR TITLE
fixed typo in .radare2rc

### DIFF
--- a/.radare2rc
+++ b/.radare2rc
@@ -1,5 +1,5 @@
 # Show comments at right of disassembly
-e asm.cmtright=true
+e asm.cmt.right=true
 
 # Shows pseudocode in disassembly. Eg mov eax, str.ok = > eax = str.ok
 e asm.pseudo = true


### PR DESCRIPTION
had typo in e asm.cmt.right=true